### PR TITLE
Add streak counter and new word categories

### DIFF
--- a/data/cebuano.json
+++ b/data/cebuano.json
@@ -81,4 +81,34 @@
   { "id": "place-church", "cebuano": "Simbahan", "english": "Church" },
   { "id": "place-market", "cebuano": "Merkado", "english": "Market" },
   { "id": "place-hospital", "cebuano": "Ospital", "english": "Hospital" }
+  ,
+  { "id": "num-zero", "cebuano": "Sero", "english": "Zero", "category": "numbers" },
+  { "id": "num-twenty", "cebuano": "Baynte", "english": "Twenty", "category": "numbers" },
+
+  { "id": "color-orange", "cebuano": "Kahel", "english": "Orange", "category": "colors" },
+  { "id": "color-purple", "cebuano": "Ube", "english": "Purple", "category": "colors" },
+  { "id": "color-pink", "cebuano": "Rosas", "english": "Pink", "category": "colors" },
+  { "id": "color-brown", "cebuano": "Brown", "english": "Brown", "category": "colors" },
+  { "id": "color-gray", "cebuano": "Abo", "english": "Gray", "category": "colors" },
+
+  { "id": "place-restaurant", "cebuano": "Restawran", "english": "Restaurant", "category": "locations" },
+  { "id": "place-hotel", "cebuano": "Hotel", "english": "Hotel", "category": "locations" },
+  { "id": "place-bank", "cebuano": "Bangko", "english": "Bank", "category": "locations" },
+  { "id": "place-beach", "cebuano": "Baybayon", "english": "Beach", "category": "locations" },
+  { "id": "place-mountain", "cebuano": "Bukid", "english": "Mountain", "category": "locations" },
+  { "id": "place-city", "cebuano": "Syudad", "english": "City", "category": "locations" },
+  { "id": "place-street", "cebuano": "Dalan", "english": "Street", "category": "locations" },
+  { "id": "place-restroom", "cebuano": "Kasilyas", "english": "Restroom / Toilet", "category": "locations" },
+  { "id": "place-store", "cebuano": "Tindahan", "english": "Store", "category": "locations" },
+  { "id": "place-pharmacy", "cebuano": "Botika", "english": "Pharmacy", "category": "locations" },
+
+  { "id": "common-where-from", "cebuano": "Taga asa ka?", "english": "Where are you from?", "category": "common" },
+  { "id": "common-how-old", "cebuano": "Pilay edad nimo?", "english": "How old are you?", "category": "common" },
+  { "id": "common-speak-english", "cebuano": "Kabalo ka mag-Iningles?", "english": "Do you speak English?", "category": "common" },
+  { "id": "common-what-time", "cebuano": "Unsa na oras?", "english": "What time is it?", "category": "common" },
+  { "id": "common-can-you-help", "cebuano": "Pwede ko nimo tabangan?", "english": "Can you help me?", "category": "common" },
+  { "id": "common-where-bathroom", "cebuano": "Asa ang kasilyas?", "english": "Where is the bathroom?", "category": "common" },
+  { "id": "common-what-mean", "cebuano": "Unsa'y pasabot ani?", "english": "What does this mean?", "category": "common" },
+  { "id": "common-how-say", "cebuano": "Unsaon pag-ingon niini sa Cebuano?", "english": "How do you say this in Cebuano?", "category": "common" },
+  { "id": "common-where-live", "cebuano": "Asa ka nagpuyo?", "english": "Where do you live?", "category": "common" }
 ]

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
           </div>
           <div class="progress-row">
             <span id="quiz-progress" aria-live="polite"></span>
+            <span id="quiz-streak" aria-live="polite"></span>
           </div>
         </div>
       </section>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -40,10 +40,19 @@
     { id: 'num-three', cebuano: 'Tulo', english: 'Three' },
     { id: 'num-four', cebuano: 'Upat', english: 'Four' },
     { id: 'num-five', cebuano: 'Lima', english: 'Five' },
+    { id: 'num-six', cebuano: 'Unom', english: 'Six' },
+    { id: 'num-seven', cebuano: 'Pito', english: 'Seven' },
+    { id: 'num-eight', cebuano: 'Walo', english: 'Eight' },
+    { id: 'num-nine', cebuano: 'Siyam', english: 'Nine' },
+    { id: 'num-ten', cebuano: 'Napulo', english: 'Ten' },
     { id: 'color-red', cebuano: 'Pula', english: 'Red' },
     { id: 'color-blue', cebuano: 'Asul', english: 'Blue' },
     { id: 'color-green', cebuano: 'Berde / lunhaw', english: 'Green' },
     { id: 'color-yellow', cebuano: 'Dilaw', english: 'Yellow' },
+    { id: 'color-black', cebuano: 'Itom', english: 'Black' },
+    { id: 'color-white', cebuano: 'Puti', english: 'White' },
+    { id: 'color-orange', cebuano: 'Kahel', english: 'Orange' },
+    { id: 'color-purple', cebuano: 'Ube', english: 'Purple' },
     { id: 'emotion-hungry', cebuano: 'Gigutom', english: 'Hungry' },
     { id: 'emotion-thirsty', cebuano: 'Gi-uhaw', english: 'Thirsty' },
     { id: 'emotion-tired', cebuano: 'Kapoy', english: 'Tired' },
@@ -54,9 +63,15 @@
     { id: 'common-i-dont-know', cebuano: 'Wala ko kahibalo', english: "I don't know" },
     { id: 'common-i-understand', cebuano: 'Nakasabot ko', english: 'I understand' },
     { id: 'common-help', cebuano: 'Tabang!', english: 'Help!' },
+    { id: 'common-where-from', cebuano: 'Taga asa ka?', english: 'Where are you from?' },
+    { id: 'common-how-old', cebuano: 'Pilay edad nimo?', english: 'How old are you?' },
+    { id: 'common-what-time', cebuano: 'Unsa na oras?', english: 'What time is it?' },
     { id: 'place-house', cebuano: 'Balay', english: 'House' },
     { id: 'place-school', cebuano: 'Eskwelahan', english: 'School' },
-    { id: 'place-market', cebuano: 'Merkado', english: 'Market' }
+    { id: 'place-market', cebuano: 'Merkado', english: 'Market' },
+    { id: 'place-bank', cebuano: 'Bangko', english: 'Bank' },
+    { id: 'place-beach', cebuano: 'Baybayon', english: 'Beach' },
+    { id: 'place-restroom', cebuano: 'Kasilyas', english: 'Restroom / Toilet' }
   ];
 
   function readLocalStorage(key, fallback) {
@@ -186,6 +201,7 @@
       quizFeedback: document.getElementById('quiz-feedback'),
       quizNext: document.getElementById('quiz-next'),
       quizProgress: document.getElementById('quiz-progress'),
+      quizStreak: document.getElementById('quiz-streak'),
       // Stats
       statTotal: document.getElementById('stat-total'),
       statMastered: document.getElementById('stat-mastered'),
@@ -295,6 +311,11 @@
       quizLocked = false;
       const p = progressById[current.id] || { score: 0, seen: 0 };
       el.quizProgress.textContent = `Score: ${p.score || 0} · Seen: ${p.seen || 0}`;
+      // Show current streak without mutating it here
+      const streak = readStreak();
+      if (el.quizStreak) {
+        el.quizStreak.textContent = `Streak: ${streak.streakCount || 0}`;
+      }
     }
 
     function answerQuiz(index) {
@@ -325,6 +346,11 @@
         });
       }
       el.quizNext.disabled = false;
+      // Update streak display after recording activity
+      const streak = readStreak();
+      if (el.quizStreak) {
+        el.quizStreak.textContent = `Streak: ${streak.streakCount || 0}`;
+      }
     }
 
     // Events


### PR DESCRIPTION
Add a streak counter to the multiple-choice quiz and expand the word pack with additional words across categories like colors, numbers, locations, and common questions.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0ec6016-ca7b-46f4-83cc-534db4f7ac65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0ec6016-ca7b-46f4-83cc-534db4f7ac65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

